### PR TITLE
Tax total now reflects tax on LaraCart fees.

### DIFF
--- a/src/LaraCart.php
+++ b/src/LaraCart.php
@@ -430,6 +430,12 @@ class LaraCart implements LaraCartContract
             }
         }
 
+        foreach ($this->getFees() as $fee) {
+            if ($fee->taxable) {
+                $totalTax += $fee->amount * $this->cart->tax;
+            }
+        }
+
         return $this->formatMoney($totalTax, null, null, $format);
     }
 
@@ -538,9 +544,6 @@ class LaraCart implements LaraCartContract
 
         foreach ($this->getFees() as $fee) {
             $feeTotal += $fee->amount;
-            if ($fee->taxable) {
-                $feeTotal += $fee->amount * $this->cart->tax;
-            }
         }
 
         return $this->formatMoney($feeTotal, null, null, $format);

--- a/tests/TotalsTest.php
+++ b/tests/TotalsTest.php
@@ -83,8 +83,11 @@ class TotalsTest extends Orchestra\Testbench\TestCase
     {
         $this->laracart->addFee('test_2', 1, true);
 
-        $this->assertEquals('$1.07', $this->laracart->feeTotals());
-        $this->assertEquals('1.07', $this->laracart->feeTotals(false));
+        $this->assertEquals('$1.00', $this->laracart->feeTotals());
+        $this->assertEquals(1, $this->laracart->feeTotals(false));
+
+        $this->assertEquals("$0.07", $this->laracart->taxTotal());
+        $this->assertEquals("0.07", $this->laracart->taxTotal(false));
     }
 
     /**


### PR DESCRIPTION
Previously if an fee was taxable it's tax was not getting reflected in the tax total. Now the tax total reflects the tax on any taxable fees.

But now the feeTotals() will return the value of the fees and not include the tax.